### PR TITLE
enabling actuator healthcheck for probes

### DIFF
--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -30,19 +30,16 @@ spec:
           volumeMounts:
             - name: config-volume
               mountPath: /config
-
-# TODO: Fix probes
-#          livenessProbe:
-#            httpGet:
-#              path: /
-#              port: 8080
-#          readinessProbe:
-#            httpGet:
-#              path: /actuator/health
-#              port: 8080
+          livenessProbe:
+            httpGet:
+              path: /actuator/health
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /actuator/health
+              port: http
           resources:
 {{ toYaml .Values.resources | indent 12 }}
-
       volumes:
         - name: config-volume
           configMap:


### PR DESCRIPTION
While the /actuator/health may not be the absolute best for readinessProbe, it should be better than nothing, until some time when there is some application-level endpoint we can call to get a 200 response.