### PR TITLE
support values-driven app config

### DIFF
--- a/helm/templates/configmap.yaml
+++ b/helm/templates/configmap.yaml
@@ -8,4 +8,5 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 data:
-  application.yaml: TODO: add config here for spring boot app.
+  application.yaml: |
+{{ toYaml .Values.applicationYaml | indent 4 }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -17,6 +17,35 @@ ingress:
   hosts:
     - auth.dniel.in
 
+## Uncomment and complete the following section to set the configuration
+# applicationYaml:
+#   domain: https://xxxxx.xx.auth0.com/
+#   token-endpoint: https://xxx.xx.auth0.com/oauth/token
+#   authorize-url: https://xxxx.xx.auth0.com/authorize
+#   default:
+#       name: www.example.test
+#       client-id: <from auth0 application config>
+#       client-secret: <from auth0 application config>
+#       audience: <from auth0 api config> or blank
+#       scope: "profile openid email"
+#       redirect-uri: http://www.example.test/oauth2/signin
+#       token-cookie-domain: example.test
+#   apps:
+#     - name: www.example.test
+#       client-id: <from auth0 application config>
+#       client-secret: <from auth0 application config>
+#       audience: <from auth0 api config> or blank
+#       scope: "profile openid email"
+#       redirect-uri: http://www.example.test/oauth2/signin
+#       token-cookie-domain: example.test
+#     - name: traefik.example.test
+#       client-id: <from auth0 application config>
+#       client-secret: <from auth0 application config>
+#       audience: <from auth0 api config> or blank
+#       scope: "profile openid email"
+#       redirect-uri: http://traefik.example.test/oauth2/signin
+#       token-cookie-domain: traefik.example.test
+
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little


### PR DESCRIPTION
The purpose of this PR is to allow a consumer of the helm chart to define the necessary application configuration in the `values.yaml` file.