### PR TITLE
values-driven loglevel

### DIFF
--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -40,6 +40,9 @@ spec:
 #            httpGet:
 #              path: /actuator/health
 #              port: 8080
+          env:
+            - name: ENV
+              value: "{{ .Values.logLevel }}"
           resources:
 {{ toYaml .Values.resources | indent 12 }}
 

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -5,6 +5,9 @@ image:
   tag: latest
   pullPolicy: Always
 
+# set logLevel to DEBUG, TEST, or PRODUCTION to control the verbosity of logs
+logLevel: DEBUG
+
 service:
   type: ClusterIP
   port: 80


### PR DESCRIPTION
The purpose of this PR is to allow a user to specify the verbosity of the logging by setting `logLevel` in the `values.yaml` to:

* DEBUG
* TEST
* PRODUCTION