### PR TITLE
Limit.methods

### DIFF
--- a/src/main/kotlin/dniel/forwardauth/AuthProperties.kt
+++ b/src/main/kotlin/dniel/forwardauth/AuthProperties.kt
@@ -33,6 +33,7 @@ class AuthProperties {
         var scope: String = ""
         var redirectUri: String = ""
         var tokenCookieDomain: String = ""
+        var restrictedMethods: Array<String> = arrayOf<String>("DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT")
 
         override fun toString(): String {
             return "Application(name='$name', clientId='$clientId', clientSecret='$clientSecret', audience='$audience', scope='$scope', redirectUrl='$redirectUri', tokenCookieDomain='$tokenCookieDomain')"
@@ -58,6 +59,7 @@ class AuthProperties {
             application.clientId = if (application.clientId.isNotEmpty()) application.clientId else default.clientId
             application.clientSecret = if (application.clientSecret.isNotEmpty()) application.clientSecret else default.clientSecret
             application.tokenCookieDomain = if (application.tokenCookieDomain.isNotEmpty()) application.tokenCookieDomain else default.tokenCookieDomain
+            application.restrictedMethods = if (application.restrictedMethods.isNotEmpty()) application.restrictedMethods else default.restrictedMethods
             return application
         } else return default;
     }

--- a/src/main/kotlin/dniel/forwardauth/AuthProperties.kt
+++ b/src/main/kotlin/dniel/forwardauth/AuthProperties.kt
@@ -30,7 +30,7 @@ class AuthProperties {
         var clientId: String = ""
         var clientSecret: String = ""
         var audience: String = ""
-        var scope: String = ""
+        var scope: String = "profile openid email"
         var redirectUri: String = ""
         var tokenCookieDomain: String = ""
         var restrictedMethods: Array<String> = arrayOf<String>("DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT")

--- a/src/main/kotlin/dniel/forwardauth/infrastructure/endpoints/AuthorizeEndpoint.kt
+++ b/src/main/kotlin/dniel/forwardauth/infrastructure/endpoints/AuthorizeEndpoint.kt
@@ -78,7 +78,7 @@ class AuthorizeEndpoint(val properties: AuthProperties,
             LOGGER.debug("SCOPES = $scopes")
             LOGGER.debug("CLIENT_ID = $clientId")
             LOGGER.debug("COOKIE DOMAIN = $tokenCookieDomain")
-            LOGGER.debug("RESTRICTED_METHODS = $restrictedMethods")
+            LOGGER.debug("RESTRICTED_METHODS = ${restrictedMethods.joinToString()}")
         }
 
         if (originUrl.startsWith(redirectUrl) || !restrictedMethods.contains(forwardedMethodHeader)) {

--- a/src/main/kotlin/dniel/forwardauth/infrastructure/endpoints/AuthorizeEndpoint.kt
+++ b/src/main/kotlin/dniel/forwardauth/infrastructure/endpoints/AuthorizeEndpoint.kt
@@ -33,26 +33,20 @@ class AuthorizeEndpoint(val properties: AuthProperties,
     fun authorize(@Context headers: HttpHeaders,
                   @CookieParam("ACCESS_TOKEN") accessTokenCookie: Cookie?,
                   @CookieParam("JWT_TOKEN") userinfoCookie: Cookie?,
-                  @HeaderParam("x-client-id") clientIdHeader: String?,
-                  @HeaderParam("x-client-secret") clientSecretHeader: String?,
-                  @HeaderParam("x-audience") audienceHeader: String?,
                   @HeaderParam("x-forwarded-host") forwardedHostHeader: String,
                   @HeaderParam("x-forwarded-proto") forwardedProtoHeader: String,
                   @HeaderParam("x-forwarded-uri") forwardedUriHeader: String,
+                  @HeaderParam("x-forwarded-method") forwardedMethodHeader: String,
                   @HeaderParam("x-forward-auth-app") forwardAuthAppHeader: String?): Response {
 
         if (LOGGER.isDebugEnabled) {
             headers.requestHeaders.forEach { requestHeader -> LOGGER.debug("Header ${requestHeader.key} = ${requestHeader.value}") }
         }
 
-        if (clientIdHeader != null && clientSecretHeader != null && audienceHeader != null) {
-            return authenticateClientCredentials(clientIdHeader, clientSecretHeader, audienceHeader, forwardedProtoHeader, forwardedHostHeader, forwardedUriHeader)
-        } else {
-            return authenticateAccessToken(accessTokenCookie, userinfoCookie, forwardAuthAppHeader, forwardedHostHeader, forwardedProtoHeader, forwardedUriHeader)
-        }
+        return authenticateAccessToken(accessTokenCookie, userinfoCookie, forwardAuthAppHeader, forwardedMethodHeader, forwardedHostHeader, forwardedProtoHeader, forwardedUriHeader)
     }
 
-    private fun authenticateAccessToken(accessTokenCookie: Cookie?, userinfoCookie: Cookie?, forwardAuthAppHeader: String?, forwardedHostHeader: String, forwardedProtoHeader: String, forwardedUriHeader: String): Response {
+    private fun authenticateAccessToken(accessTokenCookie: Cookie?, userinfoCookie: Cookie?, forwardAuthAppHeader: String?, forwardedMethodHeader: String, forwardedHostHeader: String, forwardedProtoHeader: String, forwardedUriHeader: String): Response {
         LOGGER.debug("Authorize Access Token: $forwardedProtoHeader://$forwardedHostHeader$forwardedUriHeader [accessToken=${accessTokenCookie != null}, jwt=${userinfoCookie != null}]");
         var accessToken = accessTokenCookie?.value
         val userinfo = userinfoCookie?.value
@@ -74,18 +68,20 @@ class AuthorizeEndpoint(val properties: AuthProperties,
         val authorizeUrl = AuthorizeUrl(AUTHORIZE_URL, audience, scopes.split(" ").toTypedArray(), clientId, redirectUrl, state)
         val nonceCookie = NewCookie("AUTH_NONCE", nonce.toString(), "/", tokenCookieDomain, null, -1, false);
 
-        LOGGER.debug("REDIRECT_URL = $redirectUrl")
-        LOGGER.debug("AUDIENCE  = $audience")
-        LOGGER.debug("ORIGIN_URL  = $originUrl")
-        LOGGER.debug("AUTH_URL  = $authorizeUrl")
-        LOGGER.debug("NONCE = $nonce")
-        LOGGER.debug("STATE = $state")
-        LOGGER.debug("SCOPES = $scopes")
-        LOGGER.debug("CLIENT_ID = $clientId")
-        LOGGER.debug("COOKIE DOMAIN = $tokenCookieDomain")
-        LOGGER.debug("RESTRICTED_METHODS = $restrictedMethods")
+        if (LOGGER.isDebugEnabled) {
+            LOGGER.debug("REDIRECT_URL = $redirectUrl")
+            LOGGER.debug("AUDIENCE  = $audience")
+            LOGGER.debug("ORIGIN_URL  = $originUrl")
+            LOGGER.debug("AUTH_URL  = $authorizeUrl")
+            LOGGER.debug("NONCE = $nonce")
+            LOGGER.debug("STATE = $state")
+            LOGGER.debug("SCOPES = $scopes")
+            LOGGER.debug("CLIENT_ID = $clientId")
+            LOGGER.debug("COOKIE DOMAIN = $tokenCookieDomain")
+            LOGGER.debug("RESTRICTED_METHODS = $restrictedMethods")
+        }
 
-        if (originUrl.startsWith(redirectUrl)) {
+        if (originUrl.startsWith(redirectUrl) || !restrictedMethods.contains(forwardedMethodHeader)) {
             LOGGER.debug("Access granted to $forwardedProtoHeader://$forwardedHostHeader$forwardedUriHeader")
             return Response.ok().build()
         }
@@ -111,10 +107,5 @@ class AuthorizeEndpoint(val properties: AuthProperties,
         } catch (e: Exception) {
             return Response.temporaryRedirect(authorizeUrl.toURI()).cookie(nonceCookie).build()
         }
-    }
-
-    private fun authenticateClientCredentials(clientIdHeader: String, clientSecretHeader: String, audienceHeader: String, forwardedProtoHeader: String, forwardedHostHeader: String, forwardedUriHeader: String): Response {
-        LOGGER.debug("Authorized Client Credentials: $forwardedProtoHeader://$forwardedHostHeader$forwardedUriHeader [clientId=${clientIdHeader}]")
-        TODO("add verification that the client_id and client_secret that are trying to access the specific frontend in traefik actually has permission to access it.")
     }
 }

--- a/src/main/kotlin/dniel/forwardauth/infrastructure/endpoints/AuthorizeEndpoint.kt
+++ b/src/main/kotlin/dniel/forwardauth/infrastructure/endpoints/AuthorizeEndpoint.kt
@@ -66,6 +66,7 @@ class AuthorizeEndpoint(val properties: AuthProperties,
         val scopes = app.scope
         val clientId = app.clientId
         val tokenCookieDomain = app.tokenCookieDomain
+        val restrictedMethods = app.restrictedMethods
 
         val originUrl = OriginUrl(forwardedProtoHeader, forwardedHostHeader, forwardedUriHeader)
         val nonce = nonceService.create()
@@ -82,6 +83,7 @@ class AuthorizeEndpoint(val properties: AuthProperties,
         LOGGER.debug("SCOPES = $scopes")
         LOGGER.debug("CLIENT_ID = $clientId")
         LOGGER.debug("COOKIE DOMAIN = $tokenCookieDomain")
+        LOGGER.debug("RESTRICTED_METHODS = $restrictedMethods")
 
         if (originUrl.startsWith(redirectUrl)) {
             LOGGER.debug("Access granted to $forwardedProtoHeader://$forwardedHostHeader$forwardedUriHeader")


### PR DESCRIPTION
1. remove started but not yet completed feature for client credentials
2. add new parameter in configuration "restricted-methods" that is an array with http verbs that require authentication. Default value are all verbs. Example config for an app:
```yaml
apps:
  - name: www.dniel.se
    restricted-methods:
    - DELETE
    - PATCH
    - POST
    - PUT
```
3. set default scope to "profile openid email"