### PR TITLE
Verify.access.token

### DIFF
--- a/src/main/kotlin/dniel/forwardauth/AuthProperties.kt
+++ b/src/main/kotlin/dniel/forwardauth/AuthProperties.kt
@@ -2,6 +2,7 @@ package dniel.forwardauth
 
 import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.validation.annotation.Validated
+import java.util.*
 import javax.validation.constraints.NotEmpty
 import javax.validation.constraints.NotNull
 
@@ -33,11 +34,22 @@ class AuthProperties {
         var scope: String = "profile openid email"
         var redirectUri: String = ""
         var tokenCookieDomain: String = ""
+        var verifyAccessToken: Boolean? = null
         var restrictedMethods: Array<String> = arrayOf<String>("DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT")
 
+
         override fun toString(): String {
-            return "Application(name='$name', clientId='$clientId', clientSecret='$clientSecret', audience='$audience', scope='$scope', redirectUrl='$redirectUri', tokenCookieDomain='$tokenCookieDomain')"
+            return "Application(name='$name', " +
+                    "clientId='$clientId', " +
+                    "clientSecret='$clientSecret', " +
+                    "audience='$audience', " +
+                    "scope='$scope', " +
+                    "redirectUri='$redirectUri', " +
+                    "tokenCookieDomain='$tokenCookieDomain', " +
+                    "verifyAccessToken=$verifyAccessToken, " +
+                    "restrictedMethods=${Arrays.toString(restrictedMethods)})"
         }
+
     }
 
     override fun toString(): String {
@@ -60,6 +72,7 @@ class AuthProperties {
             application.clientSecret = if (application.clientSecret.isNotEmpty()) application.clientSecret else default.clientSecret
             application.tokenCookieDomain = if (application.tokenCookieDomain.isNotEmpty()) application.tokenCookieDomain else default.tokenCookieDomain
             application.restrictedMethods = if (application.restrictedMethods.isNotEmpty()) application.restrictedMethods else default.restrictedMethods
+            application.verifyAccessToken = application.verifyAccessToken ?: default.verifyAccessToken
             return application
         } else return default;
     }

--- a/src/main/kotlin/dniel/forwardauth/domain/service/NonceService.kt
+++ b/src/main/kotlin/dniel/forwardauth/domain/service/NonceService.kt
@@ -1,6 +1,7 @@
 package dniel.forwardauth.domain.service
 
 import dniel.forwardauth.domain.Nonce
+import dniel.forwardauth.domain.State
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
 import java.util.*
@@ -13,4 +14,5 @@ class NonceService {
     fun create(): Nonce {
         return Nonce(uuid.toString().replace("-", ""))
     }
+
 }

--- a/src/main/kotlin/dniel/forwardauth/domain/service/VerifyTokenService.kt
+++ b/src/main/kotlin/dniel/forwardauth/domain/service/VerifyTokenService.kt
@@ -21,6 +21,7 @@ class VerifyTokenService(val decoder: JwtDecoder) {
             LOGGER.debug("verifyAudience Token has valid audience: expected=$expectedAudience");
         } else {
             LOGGER.error("verifyAudience Failed to verify audience: expected=$expectedAudience, actual=${decodedJWT.audience}");
+            // TODO: this should be moved out from service, should not throw a appliction exception from inside an application service.
             throw WebApplicationException("Failed to verify audience: expected=$expectedAudience, actual=${decodedJWT.audience}", Response.Status.BAD_REQUEST)
         }
 

--- a/src/main/kotlin/dniel/forwardauth/domain/service/VerifyTokenService.kt
+++ b/src/main/kotlin/dniel/forwardauth/domain/service/VerifyTokenService.kt
@@ -18,9 +18,9 @@ class VerifyTokenService(val decoder: JwtDecoder) {
 
     fun verifyAudience(decodedJWT: DecodedJWT, expectedAudience: String): DecodedJWT {
         if (decodedJWT.audience.contains(expectedAudience)) {
-            LOGGER.debug("verifyAudience Token has valid audience: expected=$expectedAudience");
+            LOGGER.debug("VerifyAudience Token has valid audience: expected=$expectedAudience");
         } else {
-            LOGGER.error("verifyAudience Failed to verify audience: expected=$expectedAudience, actual=${decodedJWT.audience}");
+            LOGGER.error("VverifyAudience Failed to verify audience: expected=$expectedAudience, actual=${decodedJWT.audience}");
             // TODO: this should be moved out from service, should not throw a appliction exception from inside an application service.
             throw WebApplicationException("Failed to verify audience: expected=$expectedAudience, actual=${decodedJWT.audience}", Response.Status.BAD_REQUEST)
         }

--- a/src/main/kotlin/dniel/forwardauth/infrastructure/endpoints/AuthorizeEndpoint.kt
+++ b/src/main/kotlin/dniel/forwardauth/infrastructure/endpoints/AuthorizeEndpoint.kt
@@ -40,9 +40,10 @@ class AuthorizeEndpoint(val properties: AuthProperties,
                   @HeaderParam("x-forward-auth-app") forwardAuthAppHeader: String?): Response {
 
         if (LOGGER.isDebugEnabled) {
-            headers.requestHeaders.forEach { requestHeader -> LOGGER.debug("Header ${requestHeader.key} = ${requestHeader.value}") }
+            for (requestHeader in headers.requestHeaders) {
+                LOGGER.trace("Header ${requestHeader.key} = ${requestHeader.value}")
+            }
         }
-
         return authenticateAccessToken(accessTokenCookie, userinfoCookie, forwardAuthAppHeader, forwardedMethodHeader, forwardedHostHeader, forwardedProtoHeader, forwardedUriHeader)
     }
 
@@ -70,25 +71,25 @@ class AuthorizeEndpoint(val properties: AuthProperties,
         val nonceCookie = NewCookie("AUTH_NONCE", nonce.toString(), "/", tokenCookieDomain, null, -1, false);
 
         if (LOGGER.isDebugEnabled) {
-            LOGGER.debug("REDIRECT_URL = $redirectUrl")
-            LOGGER.debug("AUDIENCE  = $audience")
-            LOGGER.debug("ORIGIN_URL  = $originUrl")
-            LOGGER.debug("AUTH_URL  = $authorizeUrl")
-            LOGGER.debug("NONCE = $nonce")
-            LOGGER.debug("STATE = $state")
-            LOGGER.debug("SCOPES = $scopes")
-            LOGGER.debug("CLIENT_ID = $clientId")
-            LOGGER.debug("COOKIE DOMAIN = $tokenCookieDomain")
-            LOGGER.debug("RESTRICTED_METHODS = ${restrictedMethods.joinToString()}")
-            LOGGER.debug("VERIFY_ACCESS_TOKEN = $verifyAccessToken")
+            LOGGER.trace("REDIRECT_URL = $redirectUrl")
+            LOGGER.trace("AUDIENCE  = $audience")
+            LOGGER.trace("ORIGIN_URL  = $originUrl")
+            LOGGER.trace("AUTH_URL  = $authorizeUrl")
+            LOGGER.trace("NONCE = $nonce")
+            LOGGER.trace("STATE = $state")
+            LOGGER.trace("SCOPES = $scopes")
+            LOGGER.trace("CLIENT_ID = $clientId")
+            LOGGER.trace("COOKIE DOMAIN = $tokenCookieDomain")
+            LOGGER.trace("RESTRICTED_METHODS = ${restrictedMethods.joinToString()}")
+            LOGGER.trace("VERIFY_ACCESS_TOKEN = $verifyAccessToken")
         }
 
         if (originUrl.startsWith(redirectUrl) || !restrictedMethods.contains(forwardedMethodHeader)) {
-            LOGGER.debug("Access granted to $forwardedProtoHeader://$forwardedHostHeader$forwardedUriHeader")
+            LOGGER.info("Access granted to $forwardedProtoHeader://$forwardedHostHeader$forwardedUriHeader")
             return Response.ok().build()
         }
         if (accessToken == null) {
-            LOGGER.debug("Access denied to $forwardedProtoHeader://$forwardedHostHeader$forwardedUriHeader")
+            LOGGER.info("Access denied to $forwardedProtoHeader://$forwardedHostHeader$forwardedUriHeader")
             return Response.temporaryRedirect(authorizeUrl.toURI()).cookie(nonceCookie).build()
         }
 

--- a/src/main/kotlin/dniel/forwardauth/infrastructure/endpoints/AuthorizeEndpoint.kt
+++ b/src/main/kotlin/dniel/forwardauth/infrastructure/endpoints/AuthorizeEndpoint.kt
@@ -39,16 +39,12 @@ class AuthorizeEndpoint(val properties: AuthProperties,
                   @HeaderParam("x-forwarded-method") forwardedMethodHeader: String,
                   @HeaderParam("x-forward-auth-app") forwardAuthAppHeader: String?): Response {
 
-        if (LOGGER.isDebugEnabled) {
-            for (requestHeader in headers.requestHeaders) {
-                LOGGER.trace("Header ${requestHeader.key} = ${requestHeader.value}")
-            }
-        }
-        return authenticateAccessToken(accessTokenCookie, userinfoCookie, forwardAuthAppHeader, forwardedMethodHeader, forwardedHostHeader, forwardedProtoHeader, forwardedUriHeader)
+        printHeaders(headers)
+        return authenticateToken(accessTokenCookie, userinfoCookie, forwardAuthAppHeader, forwardedMethodHeader, forwardedHostHeader, forwardedProtoHeader, forwardedUriHeader)
     }
 
-    private fun authenticateAccessToken(accessTokenCookie: Cookie?, userinfoCookie: Cookie?, forwardAuthAppHeader: String?, forwardedMethodHeader: String, forwardedHostHeader: String, forwardedProtoHeader: String, forwardedUriHeader: String): Response {
-        LOGGER.debug("Authorize Access Token: $forwardedProtoHeader://$forwardedHostHeader$forwardedUriHeader [accessToken=${accessTokenCookie != null}, jwt=${userinfoCookie != null}]");
+    private fun authenticateToken(accessTokenCookie: Cookie?, userinfoCookie: Cookie?, forwardAuthAppHeader: String?, forwardedMethodHeader: String, forwardedHostHeader: String, forwardedProtoHeader: String, forwardedUriHeader: String): Response {
+        LOGGER.debug("AuthenticateToken: $forwardedProtoHeader://$forwardedHostHeader$forwardedUriHeader [accessToken=${accessTokenCookie != null}, jwt=${userinfoCookie != null}]");
         var accessToken = accessTokenCookie?.value
         val userinfo = userinfoCookie?.value
 
@@ -70,7 +66,7 @@ class AuthorizeEndpoint(val properties: AuthProperties,
         val authorizeUrl = AuthorizeUrl(AUTHORIZE_URL, audience, scopes.split(" ").toTypedArray(), clientId, redirectUrl, state)
         val nonceCookie = NewCookie("AUTH_NONCE", nonce.toString(), "/", tokenCookieDomain, null, -1, false);
 
-        if (LOGGER.isDebugEnabled) {
+        if (LOGGER.isTraceEnabled()) {
             LOGGER.trace("REDIRECT_URL = $redirectUrl")
             LOGGER.trace("AUDIENCE  = $audience")
             LOGGER.trace("ORIGIN_URL  = $originUrl")
@@ -85,11 +81,11 @@ class AuthorizeEndpoint(val properties: AuthProperties,
         }
 
         if (originUrl.startsWith(redirectUrl) || !restrictedMethods.contains(forwardedMethodHeader)) {
-            LOGGER.info("Access granted to $forwardedProtoHeader://$forwardedHostHeader$forwardedUriHeader")
+            LOGGER.info("AuthenticateToken NonRestrictedUrl, Access granted to $forwardedProtoHeader://$forwardedHostHeader$forwardedUriHeader")
             return Response.ok().build()
         }
-        if (accessToken == null) {
-            LOGGER.info("Access denied to $forwardedProtoHeader://$forwardedHostHeader$forwardedUriHeader")
+        if (accessToken == null || userinfo == null) {
+            LOGGER.info("AuthenticateToken MissingToken, Access denied to $forwardedProtoHeader://$forwardedHostHeader$forwardedUriHeader")
             return Response.temporaryRedirect(authorizeUrl.toURI()).cookie(nonceCookie).build()
         }
 
@@ -97,20 +93,27 @@ class AuthorizeEndpoint(val properties: AuthProperties,
             verifyTokenService.verify(accessToken, audience, DOMAIN)
         }
 
+        val response = Response.ok().header("Authenticatation", "Bearer: ${accessToken}")
         try {
-            val response = Response.ok().header("Authenticatation", "Bearer: ${accessToken}")
-            if (userinfo != null) {
-                val decodedUserToken = verifyTokenService.verify(userinfo, clientId, DOMAIN)
-                response.header("X-Auth-Name", decodedUserToken.value.getClaim("name").asString())
-                        .header("X-Auth-User", decodedUserToken.value.subject)
-                        .header("X-Auth-Nick", decodedUserToken.value.getClaim("nickname").asString())
-                        .header("X-Auth-Email", decodedUserToken.value.getClaim("email").asString())
-                        .header("X-Auth-Picture", decodedUserToken.value.getClaim("picture").asString())
-            }
-            LOGGER.info("Authorized Access Token, access granted to $forwardedProtoHeader://$forwardedHostHeader$forwardedUriHeader")
-            return response.build()
+            val decodedUserToken = verifyTokenService.verify(userinfo, clientId, DOMAIN)
+            response.header("X-Auth-Name", decodedUserToken.value.getClaim("name").asString())
+                    .header("X-Auth-User", decodedUserToken.value.subject)
+                    .header("X-Auth-Nick", decodedUserToken.value.getClaim("nickname").asString())
+                    .header("X-Auth-Email", decodedUserToken.value.getClaim("email").asString())
+                    .header("X-Auth-Picture", decodedUserToken.value.getClaim("picture").asString())
+            LOGGER.info("AuthenticateToken ValidToken, access granted to $forwardedProtoHeader://$forwardedHostHeader$forwardedUriHeader")
         } catch (e: Exception) {
             return Response.temporaryRedirect(authorizeUrl.toURI()).cookie(nonceCookie).build()
         }
+        return response.build()
     }
+
+    private fun printHeaders(headers: HttpHeaders) {
+        if (LOGGER.isTraceEnabled) {
+            for (requestHeader in headers.requestHeaders) {
+                LOGGER.trace("Header ${requestHeader.key} = ${requestHeader.value}")
+            }
+        }
+    }
+
 }

--- a/src/main/kotlin/dniel/forwardauth/infrastructure/endpoints/SigninEndpoint.kt
+++ b/src/main/kotlin/dniel/forwardauth/infrastructure/endpoints/SigninEndpoint.kt
@@ -32,8 +32,10 @@ class SigninEndpoint(val properties: AuthProperties, val auth0Client: Auth0Servi
                @HeaderParam("x-forwarded-host") forwardedHost: String,
                @CookieParam("AUTH_NONCE") nonceCookie: Cookie): Response {
         LOGGER.info("Signin with code=$code")
-        for (requestHeader in headers.requestHeaders) {
-            LOGGER.info("Header ${requestHeader.key} = ${requestHeader.value}")
+        if (LOGGER.isDebugEnabled) {
+            for (requestHeader in headers.requestHeaders) {
+                LOGGER.trace("Header ${requestHeader.key} = ${requestHeader.value}")
+            }
         }
 
         val app = properties.findApplicationOrDefault(forwardedHost)

--- a/src/main/kotlin/dniel/forwardauth/infrastructure/jwt/JwtDecoder.kt
+++ b/src/main/kotlin/dniel/forwardauth/infrastructure/jwt/JwtDecoder.kt
@@ -40,8 +40,9 @@ class JwtDecoder {
 
             return decodedJwt
         } catch (e: Exception) {
-            LOGGER.error("Failed to verify token", e);
-            throw WebApplicationException("Failed to verify token", Response.Status.BAD_REQUEST)
+            val message = e.message
+            LOGGER.error("Failed to verify token, ${message}", e);
+            throw WebApplicationException("Failed to verify token, ${message}", Response.Status.BAD_REQUEST)
         }
     }
 

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -13,17 +13,17 @@
 
 
     <springProfile name="DEV">
-        <logger name="dniel" level="DEBUG" additivity="false">
+        <logger name="dniel" level="TRACE" additivity="false">
             <appender-ref ref="STDOUT"/>
         </logger>
     </springProfile>
     <springProfile name="TEST">
-        <logger name="dniel" level="INFO" additivity="false">
+        <logger name="dniel" level="DEBUG" additivity="false">
             <appender-ref ref="STDOUT"/>
         </logger>
     </springProfile>
     <springProfile name="PRODUCTION">
-        <logger name="dniel" level="WARN" additivity="false">
+        <logger name="dniel" level="INFO" additivity="false">
             <appender-ref ref="STDOUT"/>
         </logger>
     </springProfile>


### PR DESCRIPTION
New feature to enable/disable JWT verification of Access Token received from Auth0.
By default it is set to enabled. When set to false to disable it, the traefik-forward-auth0 application will not verify anything about the access token, instead it will just set it as a cookie in the browser so that the receiving API may use it.  The traefik-forward-auth0 application will still verify the JWT ID Token received to be sure that the current client_id and signature is the correct recipient of the token.

Read https://auth0.com/docs/tokens/set-access-token-format for more information about opaque tokens vs. JWT tokens from Auth0 and their use.
