### PR TITLE
Dashes instead of underscores in header names

### DIFF
--- a/src/main/kotlin/dniel/forwardauth/infrastructure/spring/controllers/AuthorizeController.kt
+++ b/src/main/kotlin/dniel/forwardauth/infrastructure/spring/controllers/AuthorizeController.kt
@@ -87,7 +87,7 @@ class AuthorizeController(val authorizeHandler: AuthorizeHandler, val commandDis
         val builder = ResponseEntity.noContent()
         builder.header("Authorization", "Bearer ${accessToken}")
         authorizeResult.userinfo.forEach { k, v ->
-            val headerName = "X-Forwardauth-${k.capitalize()}"
+            val headerName = "X-Forwardauth-${k.capitalize().replace('_', '-')}"
             LOGGER.trace("Add header ${headerName} with value ${v}")
             builder.header(headerName, v)
         }

--- a/src/main/kotlin/dniel/forwardauth/infrastructure/spring/controllers/AuthorizeController.kt
+++ b/src/main/kotlin/dniel/forwardauth/infrastructure/spring/controllers/AuthorizeController.kt
@@ -9,6 +9,7 @@ import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.util.MultiValueMap
 import org.springframework.web.bind.annotation.*
+import java.util.Locale
 import java.util.stream.Collectors
 import javax.servlet.http.Cookie
 import javax.servlet.http.HttpServletResponse
@@ -87,7 +88,7 @@ class AuthorizeController(val authorizeHandler: AuthorizeHandler, val commandDis
         val builder = ResponseEntity.noContent()
         builder.header("Authorization", "Bearer ${accessToken}")
         authorizeResult.userinfo.forEach { k, v ->
-            val headerName = "X-Forwardauth-${k.capitalize().replace('_', '-')}"
+            val headerName = "X-Forwardauth-${k.replace('_', '-')}".toLowerCase(Locale.ENGLISH)
             LOGGER.trace("Add header ${headerName} with value ${v}")
             builder.header(headerName, v)
         }


### PR DESCRIPTION
Fixes #136

Also, I am wondering weather we really want the capitalization? Currently the header from claim `given_name` becomes `X-Forwardauth-Given-name` header