### PR TITLE
Add optional existing configmap

### DIFF
--- a/helm/templates/configmap.yaml
+++ b/helm/templates/configmap.yaml
@@ -1,3 +1,4 @@
+{{ if not .Values.existingConfigMap }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -10,3 +11,4 @@ metadata:
 data:
   application.yaml: |
 {{ toYaml .Values.applicationYaml | indent 4 }}
+{{ end }}

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -114,8 +114,11 @@ spec:
       volumes:
         - name: config-volume
           configMap:
+          {{- if .Values.existingConfigMap }}
+            name: {{ .Values.existingConfigMap }}
+          {{- else }}
             name: {{ template "helm.fullname" . }}-config
-
+          {{- end }}
     {{- with .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -81,6 +81,11 @@ ingress:
   path: /auth
   tls: []
 
+# rather than constructing applicationYaml below, it may be desirable to simply mount
+# an existing configmap into the deployment as application.yaml. Specify the name
+# of this existing configmap below to ignore applicationYaml:
+existingConfigMap: null
+
 ## Uncomment and complete the following section to set the configuration
 # applicationYaml:
 #   domain: https://xxxxx.xx.auth0.com/


### PR DESCRIPTION
Hey @dniel !

Thanks for all your work on this 👍🏻 

Here's a small contribution specific to my use-case, but it may be helpful for others. I needed to use an `application.yaml` generated outside of the helm chart, so this PR introduces the `existingConfigMap` value, which simply avoids creating a configmap, and instead attempts to mount an existing configmap into the application at the expected location (`/config`).

Cheers!
D