### PR TITLE
Change api version from extensions/v1beta1 to networking.k8s.io/v1

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "2.0-rc1"
 description: A Helm chart for Kubernetes to install Auth0 Authorization application for Traefik forward authentication.
 name: forwardauth
-version: 2.0.8
+version: 2.0.14

--- a/helm/templates/ingress.yaml
+++ b/helm/templates/ingress.yaml
@@ -4,7 +4,7 @@
 {{- $ingressPath := .Values.ingress.path -}}
 {{- if .Values.mode.path -}}
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -22,9 +22,12 @@ spec:
     - http:
         paths:
           - path: {{ default "/oauth2" .Values.ingress.path | quote }}
+            pathType: ImplementationSpecific
             backend:
-              serviceName: {{ $fullName }}
-              servicePort: {{ $servicePort }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $servicePort }}
 {{- if .Values.ingress.tls }}
   tls:
 {{ toYaml .Values.ingress.tls | indent 4 }}
@@ -33,7 +36,7 @@ spec:
 
 {{- if .Values.mode.host -}}
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -52,9 +55,12 @@ spec:
     - host: {{ .Values.ingress.hostname }}
       http:
         paths:
-          - backend:
-              serviceName: {{ $fullName }}
-              servicePort: {{ $servicePort }}
+          - pathType: ImplementationSpecific
+            backend:
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $servicePort }}
 {{- if .Values.ingress.tls }}
   tls:
 {{ toYaml .Values.ingress.tls | indent 4 }}


### PR DESCRIPTION
Hi @dniel

Thanks for creating and maintaining this project.

I've been using helm to deploy this service on my k8s cluster and want  to upgrade my cluster to version 1.22. The extensions/v1beta1  API version of Ingress is no longer served as of v1.22 so this PR changes both occurences in the helm chart to the now used networking.k8s.io/v1 API version.

[https://kubernetes.io/docs/reference/using-api/deprecation-guide/](https://kubernetes.io/docs/reference/using-api/deprecation-guide/)

