### PR TITLE
Fix signout route

### DIFF
--- a/src/main/kotlin/dniel/forwardauth/application/commandhandlers/SignoutHandler.kt
+++ b/src/main/kotlin/dniel/forwardauth/application/commandhandlers/SignoutHandler.kt
@@ -46,17 +46,9 @@ class SignoutHandler(val properties: AuthProperties,
     override fun handle(params: SignoutCommand): Event {
         LOGGER.debug("Sign out from Auth0")
         val app = properties.findApplicationOrDefault(params.forwardedHost)
-        try {
-            val signout = auth0Client.signout(app.clientId, app.returnTo)
-            if (!signout.isNullOrEmpty()) {
-                LOGGER.debug("Signout done, redirect to ${signout}")
-                return SignoutEvent.SignoutRedirect(signout, app)
-            } else {
-                LOGGER.debug("Signout done.")
-                return SignoutEvent.SignoutComplete(app)
-            }
-        } catch (e: Exception) {
-            return SignoutEvent.Error(e.message!!, app)
-        }
+
+        val url = "%s?client_id=%s&returnTo=%s".format(properties.logoutEndpoint, app.clientId, java.net.URLEncoder.encode(app.returnTo, "utf-8"))
+
+        return SignoutEvent.SignoutRedirect(url, app)
     }
 }

--- a/src/main/kotlin/dniel/forwardauth/infrastructure/spring/controllers/SignoutController.kt
+++ b/src/main/kotlin/dniel/forwardauth/infrastructure/spring/controllers/SignoutController.kt
@@ -6,6 +6,7 @@ import dniel.forwardauth.domain.shared.Application
 import dniel.forwardauth.infrastructure.spring.exceptions.ApplicationException
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.util.MultiValueMap

--- a/src/main/kotlin/dniel/forwardauth/infrastructure/spring/controllers/SignoutController.kt
+++ b/src/main/kotlin/dniel/forwardauth/infrastructure/spring/controllers/SignoutController.kt
@@ -6,7 +6,6 @@ import dniel.forwardauth.domain.shared.Application
 import dniel.forwardauth.infrastructure.spring.exceptions.ApplicationException
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
-import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.util.MultiValueMap


### PR DESCRIPTION
Hey, thanks for this briliant tool, please note I haven't written any applications in kotlin before and this is a very quick fix.

Current implementation of signout is not removing auth0 session browser cookies for the user, meaning, currently if the user returns to the application imidiately after signing out they will not be required to sign back in through auth0 single sign on, they will just get access to the app.

expected behaviour:

user signout -> user redirected to logout url -> user returns to application -> user is required to authenticate though auth0 signle sign on -> user is redirected to the application

actual behaviour:

user signout -> user redirected to logout url -> user returns to application -> user is assumed to be logged in


